### PR TITLE
Start date end date

### DIFF
--- a/Datepicker.js
+++ b/Datepicker.js
@@ -161,7 +161,7 @@ class clsDatepicker {
         yearInput.setAttribute("aria-label", "datepicker-year-input");
         yearInput.value = this.moment.year();
         yearInput.addEventListener('change', function (e) {
-            if (parseInt(yearInput.value) > parseInt(this.moment.year() + 20) || parseInt(yearInput.value) < parseInt(this.moment.year() - 20) ) {
+            if (parseInt(yearInput.value) > parseInt(this.moment.year() + 20) || parseInt(yearInput.value) < parseInt(this.moment.year() - 20)) {
                 yearInput.value = this.moment.year();
                 return;
             }
@@ -763,28 +763,28 @@ class clsDatepicker {
         }
     }
     // helper method to set dates if provided, return dates if not.
-    value(dates, format) {
+    value(dates, format = this.format) {
         if (typeof dates === "object") {
             // user supplied at least one date, set that date in the UI and Datepicker state.
-            this.dates[0] = moment(dates[0])._i;
-            this.dates[1] = dates[1] ? moment(dates[1])._i : "";
-            if (format) {
+            this.dates[0] = dates[0] ? moment(dates[0])._i : this.dates[0];
+            this.dates[1] = dates[1] ? moment(dates[1])._i : this.dates[1];
+            if (this.dates[0]) {
                 this.dates[0] = moment(dates[0], format)._i;
-                if (dates[1]) {
-                    this.dates[1] = moment(dates[1], format)._i;
-                }
+            }
+            if (dates[1]) {
+                this.dates[1] = moment(dates[1], format)._i;
             }
             // invoke highlighting fn to ensure calendar UI is updated
             this.highlightDates();
             this.setTime(true);
             this.drawInputElement();
-        } else if (!dates || typeof dates === undefined) {
+        } else if (!dates || typeof dates === undefined || !this.dates.length) {
             // no date supplied, return the dates from the Datepicker state
-            if (format) {
+            if (dates[0]) {
                 dates[0] = moment(dates[0]).format(format)._i;
-                if (dates[1]) {
-                    dates[1] = moment(dates[1]).format(format)._i;
-                }
+            }
+            if (dates[1]) {
+                dates[1] = moment(dates[1]).format(format)._i;
             }
             if (this.singleDate) {
                 return new Date(this.dates[0])
@@ -795,10 +795,7 @@ class clsDatepicker {
                 return dates;
             }
         } else if (typeof dates === "string" || typeof dates === "number") {
-            this.dates[0] = moment(dates)._i;
-            if (format) {
-                this.dates[0] = moment(dates, format)._i;
-            }
+            this.dates[0] = moment(dates, format)._i;
             // invoke highlighting fn to ensure calendar UI is updated
             this.highlightDates();
             this.setTime(true);
@@ -806,10 +803,16 @@ class clsDatepicker {
         }
     }
     // returns start date only
-    startDate() {
+    startDate(value) {
+        if (value) {
+            this.value([value, ""]);
+        }
         return new Date(this.dates[0]);
     }
-    endDate() {
+    endDate(value) {
+        if (value) {
+            this.value(["", value]);
+        }
         return new Date(this.dates[1]);
     }
     // helpers to hide calendar when clicked off.

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -1027,13 +1027,24 @@ class clsDatepicker {
     // helper that snaps the calendar UI to a given date
     snapTo(date = this.moment) {
         this.moment = moment(date);
-        this.containerElement.innerHTML = '';
-        this.drawCalendar();
-        this.drawInputElement();
-        this.drawPresetMenu();
-        this.closePresetMenu();
-        this.setTime(true);
-        this.highlightDates(true);
+        if (this.isVisible(this.calendarElement)) {
+            this.containerElement.innerHTML = '';
+            this.drawCalendar();
+            this.drawInputElement();
+            this.drawPresetMenu();
+            this.closePresetMenu();
+            this.setTime(true);
+            this.highlightDates(true);
+        } else {
+            this.containerElement.innerHTML = '';
+            this.drawCalendar();
+            this.drawInputElement();
+            this.drawPresetMenu();
+            this.closePresetMenu();
+            this.setTime(true);
+            this.highlightDates(true);
+            this.closeCalendar();
+        }
     }
     // helpers to convert times 12h to 24h and reverse
     toAmPm(hour) {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -766,13 +766,17 @@ class clsDatepicker {
     value(dates, format = this.format) {
         if (typeof dates === "object") {
             if (dates[0]) {
-                this.dates[0] = moment(dates[0], format);
+                this.dates[0] = moment(dates[0], format)._i;
             }
             if (dates[1]) {
-                this.dates[1] = moment(dates[1], format);
+                this.dates[1] = moment(dates[1], format)._i;
             }
             if (!dates[0] && !dates[1] && typeof dates === "object") {
+                if (!this.singleDate) {
+                    console.warn("Datepicker.js - WARNING: Use Datepicker.startDate(value) or Datepicker.endDate(value) to set single values. Your date will be set as the start date by default. ");
+                }
                 this.dates[1] = moment(dates[1], format)._i;
+                this.dates[0] = moment(this.dates[0], format)._i;
             } 
             // invoke highlighting fn to ensure calendar UI is updated
             this.highlightDates();
@@ -795,6 +799,9 @@ class clsDatepicker {
                 return dates;
             }
         } else if (typeof dates === "string" || typeof dates === "number") {
+            if (!this.singleDate) {
+                console.warn("Datepicker.js - WARNING: Use Datepicker.startDate(value) or Datepicker.endDate(value) to set single values. Your date will be set as the start date by default. ");
+            }
             this.dates[0] = moment(dates, format)._i;
             // invoke highlighting fn to ensure calendar UI is updated
             this.highlightDates();
@@ -813,7 +820,7 @@ class clsDatepicker {
         if (value) {
             this.value(["", value]);
         }
-        return typeof new Date(this.dates[1]);
+        return new Date(this.dates[1]);
     }
     // helpers to hide calendar when clicked off.
     isVisible(elem) {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -805,6 +805,13 @@ class clsDatepicker {
             this.drawInputElement();
         }
     }
+    // returns start date only
+    startDate() {
+        return new Date(this.dates[0]);
+    }
+    endDate() {
+        return new Date(this.dates[1]);
+    }
     // helpers to hide calendar when clicked off.
     isVisible(elem) {
         return !!elem && !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length) && (elem.style.display === 'grid' || elem.style.display === 'block' || elem.style.visibility === "");

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -765,26 +765,26 @@ class clsDatepicker {
     // helper method to set dates if provided, return dates if not.
     value(dates, format = this.format) {
         if (typeof dates === "object") {
-            // user supplied at least one date, set that date in the UI and Datepicker state.
-            this.dates[0] = dates[0] ? moment(dates[0])._i : this.dates[0];
-            this.dates[1] = dates[1] ? moment(dates[1])._i : this.dates[1];
-            if (this.dates[0]) {
-                this.dates[0] = moment(dates[0], format)._i;
+            if (dates[0]) {
+                this.dates[0] = moment(dates[0], format);
             }
             if (dates[1]) {
-                this.dates[1] = moment(dates[1], format)._i;
+                this.dates[1] = moment(dates[1], format);
             }
+            if (!dates[0] && !dates[1] && typeof dates === "object") {
+                this.dates[1] = moment(dates[1], format)._i;
+            } 
             // invoke highlighting fn to ensure calendar UI is updated
             this.highlightDates();
             this.setTime(true);
             this.drawInputElement();
         } else if (!dates || typeof dates === undefined || !this.dates.length) {
             // no date supplied, return the dates from the Datepicker state
-            if (dates[0]) {
-                dates[0] = moment(dates[0]).format(format)._i;
+            if (this.dates[0]) {
+                this.dates[0] = moment(this.dates[0]).format(format);
             }
-            if (dates[1]) {
-                dates[1] = moment(dates[1]).format(format)._i;
+            if (this.dates[1]) {
+                this.dates[1] = moment(this.dates[1]).format(format);
             }
             if (this.singleDate) {
                 return new Date(this.dates[0])
@@ -813,7 +813,7 @@ class clsDatepicker {
         if (value) {
             this.value(["", value]);
         }
-        return new Date(this.dates[1]);
+        return typeof new Date(this.dates[1]);
     }
     // helpers to hide calendar when clicked off.
     isVisible(elem) {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -783,6 +783,7 @@ class clsDatepicker {
             // ensure calendar UI is updated
             if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
                 let dates = [];
+                console.warn("Datepicker.js - WARNING: Entered a startDate greater than endDate, your dates were swapped to be chronologically correct.");
                 dates[0] = this.dates[1];
                 dates[1] = this.dates[0];
                 this.dates = dates;
@@ -812,6 +813,7 @@ class clsDatepicker {
             // ensure calendar UI is updated
             if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
                 let dates = [];
+                console.warn("Datepicker.js - WARNING: Entered a startDate greater than endDate, your dates were swapped to be chronologically correct.");
                 dates[0] = this.dates[1];
                 dates[1] = this.dates[0];
                 this.dates = dates;

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -47,6 +47,8 @@ class clsDatepicker {
         this.closePresetMenu = this.closePresetMenu.bind(this);
         this.resetCalendar = this.resetCalendar.bind(this);
         this.value = this.value.bind(this);
+        this.startDate = this.startDate.bind(this);
+        this.endDate = this.endDate.bind(this);
         this.outsideCalendarClick = this.outsideCalendarClick.bind(this);
         this.isOutsideCalendar = this.isOutsideCalendar.bind(this);
         this.leadingTrailing = this.leadingTrailing.bind(this);
@@ -777,8 +779,14 @@ class clsDatepicker {
                 }
                 this.dates[1] = moment(dates, format)._i;
                 this.dates[0] = moment(this.dates[0], format)._i;
-            } 
+            }
             // ensure calendar UI is updated
+            if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
+                let dates = [];
+                dates[0] = this.dates[1];
+                dates[1] = this.dates[0];
+                this.dates = dates;
+            }
             this.snapTo(this.dates[0]);
         } else if (!dates || typeof dates === undefined || !this.dates.length) {
             // no date supplied, return the dates from the Datepicker state
@@ -802,6 +810,12 @@ class clsDatepicker {
             }
             this.dates[0] = moment(dates, format)._i;
             // ensure calendar UI is updated
+            if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
+                let dates = [];
+                dates[0] = this.dates[1];
+                dates[1] = this.dates[0];
+                this.dates = dates;
+            }
             this.snapTo(this.dates[0]);
         }
     }

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -783,7 +783,7 @@ class clsDatepicker {
             // ensure calendar UI is updated
             if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
                 let dates = [];
-                console.warn("Datepicker.js - WARNING: Entered a startDate greater than endDate, your dates were swapped to be chronologically correct.");
+                console.warn("Datepicker.js - WARNING: Tried to set a startDate greater than endDate, your dates were swapped to be chronologically correct.");
                 dates[0] = this.dates[1];
                 dates[1] = this.dates[0];
                 this.dates = dates;
@@ -813,7 +813,7 @@ class clsDatepicker {
             // ensure calendar UI is updated
             if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
                 let dates = [];
-                console.warn("Datepicker.js - WARNING: Entered a startDate greater than endDate, your dates were swapped to be chronologically correct.");
+                console.warn("Datepicker.js - WARNING: Tried to set a startDate greater than endDate, your dates were swapped to be chronologically correct.");
                 dates[0] = this.dates[1];
                 dates[1] = this.dates[0];
                 this.dates = dates;

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -775,13 +775,11 @@ class clsDatepicker {
                 if (!this.singleDate) {
                     console.warn("Datepicker.js - WARNING: Use Datepicker.startDate(value) or Datepicker.endDate(value) to set single values. Your date will be set as the start date by default. ");
                 }
-                this.dates[1] = moment(dates[1], format)._i;
+                this.dates[1] = moment(dates, format)._i;
                 this.dates[0] = moment(this.dates[0], format)._i;
             } 
-            // invoke highlighting fn to ensure calendar UI is updated
-            this.highlightDates();
-            this.setTime(true);
-            this.drawInputElement();
+            // ensure calendar UI is updated
+            this.snapTo(this.dates[0]);
         } else if (!dates || typeof dates === undefined || !this.dates.length) {
             // no date supplied, return the dates from the Datepicker state
             if (this.dates[0]) {
@@ -803,10 +801,8 @@ class clsDatepicker {
                 console.warn("Datepicker.js - WARNING: Use Datepicker.startDate(value) or Datepicker.endDate(value) to set single values. Your date will be set as the start date by default. ");
             }
             this.dates[0] = moment(dates, format)._i;
-            // invoke highlighting fn to ensure calendar UI is updated
-            this.highlightDates();
-            this.setTime(true);
-            this.drawInputElement();
+            // ensure calendar UI is updated
+            this.snapTo(this.dates[0]);
         }
     }
     // returns start date only


### PR DESCRIPTION
add `startDate()` and `endDate()` methods, updated `.value()` syntax to catch more edge cases and correct formatting. Other related bug fixes.