### PR TITLE
add extra logic into hour value onChange events

### DIFF
--- a/Datepicker.js
+++ b/Datepicker.js
@@ -566,6 +566,11 @@ class Datepicker {
         this.timeElements.startHourValueEl = startHourValueEl;
 
         let startHourChange = function (event) {
+            if (this.timeElements.startHourValueEl.value > 12 && !this.militaryTime) {
+                this.timeElements.startpm.click();
+            } else {
+                this.timeElements.startam.click();
+            }
             let newVal = !this.militaryTime ? this.toMilitary(parseInt(this.timeElements.startHourValueEl.value)) : parseInt(this.timeElements.startHourValueEl.value);
             if (newVal > 23) {
                 newVal = 0;
@@ -750,6 +755,11 @@ class Datepicker {
             let endHourValueEl = endHour.querySelector("#endHour");
             this.timeElements.endHourValueEl = endHourValueEl;
             let endHourChange = function (event) {
+                if (this.timeElements.endHourValueEl.value > 12 && !this.militaryTime) {
+                    this.timeElements.endpm.click();
+                } else {
+                    this.timeElements.startpm.click();
+                }
                 let newVal = !this.militaryTime ? this.toMilitary(parseInt(this.timeElements.endHourValueEl.value)) : parseInt(this.timeElements.endHourValueEl.value);
                 if (newVal > 23) {
                     newVal = 0;
@@ -1030,6 +1040,7 @@ class Datepicker {
                 this.endHour = parseInt(this.timeElements.endHourValueEl.value);
                 this.endMinute = parseInt(this.timeElements.endMinuteValueEl.value);
             }
+
             // Sanitizes the UI and the state if .value() was used to set dates/times
             if (setProgrammatically) {
                 let startHour = this.dates[0] ? (this.militaryTime ? moment(this.dates[0]).hours() : this.toAmPm(moment(this.dates[0]).hours())) : this.timeElements.startHourValueEl.value;


### PR DESCRIPTION
changing an hour value to a 24hr value when Datepicker option is set to 12hr time will now properly click the appropriate am/pm element to track changes in state.