### PR TITLE
Defaults

### DIFF
--- a/Datepicker.html
+++ b/Datepicker.html
@@ -24,7 +24,7 @@
         militaryTime: false,
         // max: moment("08/14/2022"),
         // min: moment("08/14/2021"),
-        defaults: [new Date(), new Date()],
+        // defaults: [new Date(), new Date()],
         menuOptions: [{ title: 'Today', values: [new Date(), new Date()] }],
         startDateLabel: "Event Start: ",
         endDateLabel: "Event End: ",

--- a/Datepicker.html
+++ b/Datepicker.html
@@ -24,7 +24,7 @@
         militaryTime: false,
         // max: moment("08/14/2022"),
         // min: moment("08/14/2021"),
-        // defaults: [new Date(), new Date()],
+        defaults: [new Date(), new Date()],
         menuOptions: [{ title: 'Today', values: [new Date(), new Date()] }],
         startDateLabel: "Event Start: ",
         endDateLabel: "Event End: ",

--- a/Datepicker.html
+++ b/Datepicker.html
@@ -24,6 +24,7 @@
         militaryTime: false,
         // max: moment("08/14/2022"),
         // min: moment("08/14/2021"),
+        defaults: [new Date(), new Date()],
         menuOptions: [{ title: 'Today', values: [new Date(), new Date()] }],
         startDateLabel: "Event Start: ",
         endDateLabel: "Event End: ",

--- a/Datepicker.html
+++ b/Datepicker.html
@@ -24,19 +24,19 @@
         militaryTime: false,
         // max: moment("08/14/2022"),
         // min: moment("08/14/2021"),
-        defaults: [new Date(), new Date()],
+        // defaults: [new Date(), new Date()],
         menuOptions: [{ title: 'Today', values: [new Date(), new Date()] }],
         startDateLabel: "Event Start: ",
         endDateLabel: "Event End: ",
-        onChange: function () {
-            console.log("onChange:", this.dates);
-        },
-        onSubmit: function () {
-            console.log("onSubmit:", this.dates);
-        },
-        onClose: function () {
-            console.log("onClose:", this.dates);
-        }
+        // onChange: function () {
+        //     console.log("onChange:", this.dates);
+        // },
+        // onSubmit: function () {
+        //     console.log("onSubmit:", this.dates);
+        // },
+        // onClose: function () {
+        //     console.log("onClose:", this.dates);
+        // }
     });
 </script>
 

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -1167,19 +1167,23 @@ class Datepicker {
                     dates[0] = this.convertStringDate(dates[0]);
                 }
                 this.dates[0] = dates[0];
+            } else if (this.defaults && this.defaults.length === 1) {
+                this.dates[0] = moment(this.defaults[0]).format(format);
             }
             if (dates[1]) {
                 if (typeof dates[1] === 'string') {
                     dates[1] = this.convertStringDate(dates[1]);
                 }
                 this.dates[1] = dates[1];
+            }  else if (this.defaults && this.defaults.length === 2) {
+                this.dates[1] = moment(this.defaults[1]).format(format);
             }
             if (!dates[0] && !dates[1] && typeof dates === "object") {
                 if (!this.singleDate) {
                     console.warn("Datepicker.js - WARNING: Use Datepicker.startDate(value) or Datepicker.endDate(value) to set single values. Your date will be set as the start date by default. ");
                 }
                 this.dates[1] = moment(dates, format);
-                this.dates[0] = moment(this.dates[0], format);
+                this.dates[0] = moment(this.dates[0], format) ;
             }
             // ensure calendar UI is updated
             if (this.dates.length === 2 && moment(this.dates[0]) > moment(this.dates[1])) {
@@ -1196,16 +1200,20 @@ class Datepicker {
             // no date supplied, return the dates from the Datepicker state
             if (this.dates[0]) {
                 this.dates[0] = moment(this.dates[0]).format(format);
+            } else if (this.defaults && this.defaults.length === 1) {
+                this.dates[0] = moment(this.defaults[0]).format(format);
             }
             if (this.dates[1]) {
                 this.dates[1] = moment(this.dates[1]).format(format);
+            } else if (this.defaults && this.defaults.length === 1) {
+                this.dates[1] = moment(this.defaults[1]).format(format);
             }
             if (this.singleDate) {
-                return new Date(this.dates[0])
+                return (new Date(this.dates[0]) || new Date(this.defaults[0]));
             } else {
                 let dates = [];
-                dates[0] = new Date(this.dates[0]);
-                dates[1] = new Date(this.dates[1]);
+                dates[0] = new Date(this.dates[0])  || new Date(this.defaults[0]);
+                dates[1] = new Date(this.dates[1])  || new Date(this.defaults[1]);
                 return format ? [moment(dates[0]).format(format), moment(dates[1]).format(format)] : dates;
             }
         } else if (typeof dates === "string" || typeof dates === "number") {
@@ -1227,24 +1235,24 @@ class Datepicker {
         }
 
         if ((!dates[1] || !(new Date(dates[1]))) && !this.singleDate && (!dates[0] || !(new Date(dates[0])))) {
-            console.error("Datepicker.js - ERROR: Tried to set dates with invalid format or null values!");
+            console.error("Datepicker.js - ERROR: Tried to set dates with invalid format or null values, start/end dates will be set to defaults if provided.");
         } else if ((!dates[1] || !(new Date(dates[1]))) && !this.singleDate) {
-            console.warn("Datepicker.js - WARNING: No end date value provided, or tried to set [start, end] date with invalid or null end date value!");
+            console.warn("Datepicker.js - WARNING: No end date value provided, or tried to set [start, end] date with invalid or null end date value, end date will be set to default if provided.");
         } else if ((!dates[0] || !(new Date(dates[0]))) && !this.singleDate) {
-            console.warn("Datepicker.js - WARNING: No start date value provided, or tried to set [start, end] date with invalid or null start date value!");
+            console.warn("Datepicker.js - WARNING: No start date value provided, or tried to set [start, end] date with invalid or null start date value, start date will be set to default if provided.");
         }
     }
     // returns start date only
     startDate(value) {
         if (value !== undefined && value !== null && value) {
-            this.value([value, (this.dates[1] || null)]);
+            this.value([value, (this.dates[1] || this.defaults[1] || null)]);
         } else {
             return new Date(this.dates[0]);
         }
     }
     endDate(value) {
         if (value !== undefined && value !== null && value) {
-            this.value([(this.dates[0] || null), value]);
+            this.value([(this.dates[0] || this.defaults[0] || null), value]);
         } else {
             return new Date(this.dates[1]);
         }

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -1167,6 +1167,7 @@ class Datepicker {
                     dates[0] = this.convertStringDate(dates[0]);
                 }
                 this.dates[0] = dates[0];
+                this.defaults[0] = dates[0];
             } else if (this.defaults && this.defaults.length === 1) {
                 this.dates[0] = moment(this.defaults[0]).format(format);
             }
@@ -1175,6 +1176,7 @@ class Datepicker {
                     dates[1] = this.convertStringDate(dates[1]);
                 }
                 this.dates[1] = dates[1];
+                this.defaults[1] = dates[1];
             }  else if (this.defaults && this.defaults.length === 2) {
                 this.dates[1] = moment(this.defaults[1]).format(format);
             }
@@ -1212,8 +1214,8 @@ class Datepicker {
                 return (new Date(this.dates[0]) || new Date(this.defaults[0]));
             } else {
                 let dates = [];
-                dates[0] = new Date(this.dates[0])  || new Date(this.defaults[0]);
-                dates[1] = new Date(this.dates[1])  || new Date(this.defaults[1]);
+                dates[0] = new Date(this.dates[0]);
+                dates[1] = new Date(this.dates[1]);
                 return format ? [moment(dates[0]).format(format), moment(dates[1]).format(format)] : dates;
             }
         } else if (typeof dates === "string" || typeof dates === "number") {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -94,10 +94,11 @@ class Datepicker {
         this.timeValid = this.timeValid.bind(this);
         console.log(this.options.defaults)
 
-        this.defaults =  this.options.defaults !== undefined ? this.options.defaults : [];
-        this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);
-        this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? moment(this.options.defaults[1]).format(this.format): moment(moment(), this.format, true);
-        console.log(this.defaults)
+        this.defaults =  this.options.defaults !== undefined ? this.options.defaults : false;
+        if (this.defaults) {
+            this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);
+            this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? moment(this.options.defaults[1]).format(this.format): moment(moment(), this.format, true);
+        }
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};
@@ -1528,6 +1529,16 @@ class Datepicker {
     }
     closeCalendar() {
         this.onClose();
+        if (!this.dates.length && this.defaults && this.defaults.length) {
+            this.dates[0] = moment(this.defaults[0]).format(this.format);
+        }
+        if (!this.dates.length !== 2 && this.defaults && this.defaults.length === 2) {
+            if (this.dates[0]) {
+                this.dates[1] = moment(this.dates[0]).format(this.format);
+            } else {
+                this.dates[1] = moment(this.defaults[1]).format(this.format);
+            }
+        }
         this.calendarElement.hideCalendar();
         this.drawInputElement();
     }

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -93,8 +93,8 @@ class Datepicker {
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
         this.defaults =  this.options.defaults !== undefined ? this.options.defaults : [];
-        this.defaults[0] = this.options.defaults.length === 1 ? this.options.defaults[0] : moment(moment(), this.format, true);
-        this.defaults[1] = this.options.defaults.length === 2 ? this.options.defaults[1] : moment(moment(), this.format, true);
+        this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length === 1 ? this.options.defaults[0] : moment(moment(), this.format, true);
+        this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? this.options.defaults[1] : moment(moment(), this.format, true);
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -92,9 +92,12 @@ class Datepicker {
         this.snapTo = this.snapTo.bind(this);
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
+        console.log(this.options.defaults)
+
         this.defaults =  this.options.defaults !== undefined ? this.options.defaults : [];
-        this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length === 1 ? this.options.defaults[0] : moment(moment(), this.format, true);
-        this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? this.options.defaults[1] : moment(moment(), this.format, true);
+        this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);
+        this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? moment(this.options.defaults[1]).format(this.format): moment(moment(), this.format, true);
+        console.log(this.defaults)
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};
@@ -1168,7 +1171,7 @@ class Datepicker {
                 }
                 this.dates[0] = dates[0];
                 this.defaults[0] = dates[0];
-            } else if (this.defaults && this.defaults.length === 1) {
+            } else if (this.defaults && this.defaults.length) {
                 this.dates[0] = moment(this.defaults[0]).format(format);
             }
             if (dates[1]) {
@@ -1200,9 +1203,10 @@ class Datepicker {
             this.highlightDates();
         } else if (!dates || typeof dates === undefined || !this.dates.length) {
             // no date supplied, return the dates from the Datepicker state
+            // console.log(this.dates, dates,  this.defaults)
             if (this.dates[0]) {
                 this.dates[0] = moment(this.dates[0]).format(format);
-            } else if (this.defaults && this.defaults.length === 1) {
+            } else if (this.defaults && this.defaults.length) {
                 this.dates[0] = moment(this.defaults[0]).format(format);
             }
             if (this.dates[1]) {
@@ -1214,8 +1218,8 @@ class Datepicker {
                 return (new Date(this.dates[0]) || new Date(this.defaults[0]));
             } else {
                 let dates = [];
-                dates[0] = new Date(this.dates[0]);
-                dates[1] = new Date(this.dates[1]);
+                dates[0] = new Date(this.dates[0]) || new Date(this.defaults[0]);
+                dates[1] = new Date(this.dates[1]) || new Date(this.defaults[1]);
                 return format ? [moment(dates[0]).format(format), moment(dates[1]).format(format)] : dates;
             }
         } else if (typeof dates === "string" || typeof dates === "number") {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -93,8 +93,8 @@ class Datepicker {
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
         this.defaults = [];
-        this.options.defaults[0] = this.options.defaults !== undefined || this.options.defaults[0] ? this.options.defaults[0] : moment(moment(), this.format, true);
-        this.options.defaults[1] = this.options.defaults !== undefined || this.options.defaults[1] ? this.options.defaults[1] : moment(moment(), this.format, true);
+        this.defaults[0] = this.options.defaults !== undefined ? this.options.defaults[0] : moment(moment(), this.format, true);
+        this.defaults[1] = this.options.defaults !== undefined ? this.options.defaults[1] : moment(moment(), this.format, true);
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -1205,7 +1205,7 @@ class Datepicker {
             }
             if (this.dates[1]) {
                 this.dates[1] = moment(this.dates[1]).format(format);
-            } else if (this.defaults && this.defaults.length === 1) {
+            } else if (this.defaults && this.defaults.length === 2) {
                 this.dates[1] = moment(this.defaults[1]).format(format);
             }
             if (this.singleDate) {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -93,8 +93,8 @@ class Datepicker {
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
         this.defaults = [];
-        this.options.defaults[0] = this.options.defaults[0] !== undefined || !this.options.defaults[0] ? this.options.defaults[0] : moment(moment(), this.format, true);
-        this.options.defaults[1] = this.options.defaults[1] !== undefined || !this.options.defaults[1] ? this.options.defaults[1] : moment(moment(), this.format, true);
+        this.options.defaults[0] = this.options.defaults !== undefined || this.options.defaults[0] ? this.options.defaults[0] : moment(moment(), this.format, true);
+        this.options.defaults[1] = this.options.defaults !== undefined || this.options.defaults[1] ? this.options.defaults[1] : moment(moment(), this.format, true);
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -92,6 +92,9 @@ class Datepicker {
         this.snapTo = this.snapTo.bind(this);
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
+        this.defaults = [];
+        this.options.defaults[0] = this.options.defaults[0] !== undefined || !this.options.defaults[0] ? this.options.defaults[0] : moment(moment(), this.format, true);
+        this.options.defaults[1] = this.options.defaults[1] !== undefined || !this.options.defaults[1] ? this.options.defaults[1] : moment(moment(), this.format, true);
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -92,8 +92,7 @@ class Datepicker {
         this.snapTo = this.snapTo.bind(this);
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
-        console.log(this.options.defaults)
-
+        // default dates to be determined programmatically.        
         this.defaults =  this.options.defaults !== undefined ? this.options.defaults : false;
         if (this.defaults) {
             this.defaults[0] = this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -96,8 +96,8 @@ class Datepicker {
 
         this.defaults =  this.options.defaults !== undefined ? this.options.defaults : false;
         if (this.defaults) {
-            this.defaults[0] = this.options.defaults !== undefined && this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);
-            this.defaults[1] = this.options.defaults !== undefined && this.options.defaults.length === 2 ? moment(this.options.defaults[1]).format(this.format): moment(moment(), this.format, true);
+            this.defaults[0] = this.options.defaults.length ? moment(this.options.defaults[0]).format(this.format) : moment(moment(), this.format, true);
+            this.defaults[1] = this.options.defaults.length === 2 ? moment(this.options.defaults[1]).format(this.format) : moment(moment(), this.format, true);
         }
         // state values, not typically set programmatically.
         this.dates = [];
@@ -1532,7 +1532,7 @@ class Datepicker {
         if (!this.dates.length && this.defaults && this.defaults.length) {
             this.dates[0] = moment(this.defaults[0]).format(this.format);
         }
-        if (!this.dates.length !== 2 && this.defaults && this.defaults.length === 2) {
+        if (this.dates.length !== 2 && this.defaults && this.defaults.length === 2) {
             if (this.dates[0]) {
                 this.dates[1] = moment(this.dates[0]).format(this.format);
             } else {

--- a/Datepicker.js
+++ b/Datepicker.js
@@ -92,9 +92,9 @@ class Datepicker {
         this.snapTo = this.snapTo.bind(this);
         this.toAmPm = this.toAmPm.bind(this);
         this.timeValid = this.timeValid.bind(this);
-        this.defaults = [];
-        this.defaults[0] = this.options.defaults !== undefined ? this.options.defaults[0] : moment(moment(), this.format, true);
-        this.defaults[1] = this.options.defaults !== undefined ? this.options.defaults[1] : moment(moment(), this.format, true);
+        this.defaults =  this.options.defaults !== undefined ? this.options.defaults : [];
+        this.defaults[0] = this.options.defaults.length === 1 ? this.options.defaults[0] : moment(moment(), this.format, true);
+        this.defaults[1] = this.options.defaults.length === 2 ? this.options.defaults[1] : moment(moment(), this.format, true);
         // state values, not typically set programmatically.
         this.dates = [];
         this.timeElements = {};


### PR DESCRIPTION
Add defaults option to state props, add logic to `.value()` and `.onClose` to set dates to defaults if any are missing. Other minor tweaks to ensure all options work together successfully. 